### PR TITLE
Add support for schema registry authentication

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ sourceCompatibility = 1.11
 
 jar {
     manifest {
-        attributes "Main-Class": "net.christophschubert.kafka.clusterstate.CLI"
+        attributes "Main-Class": "net.christophschubert.kafka.clusterstate.cli.CLI"
     }
 
     from {


### PR DESCRIPTION
I've made 2 small modifications I had to do to make it work in our customer environment: 

- passing properties prefixed by "schema.registry." to the configure method.
- The main class name in the manifest was not corresponding to the current main class name